### PR TITLE
Fix type-o in the base install.yaml storageClassName

### DIFF
--- a/base/install.yaml
+++ b/base/install.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       accessModes:
         - ReadWriteOnce
-      storageClassName: deafault
+      storageClassName: default
       # NOTE: You can increase the storage size
       resources:
         requests:


### PR DESCRIPTION
Fix a type-o in the value of the `storageClassName`. Change from `deafault` => `default`.